### PR TITLE
Enhance audit logging

### DIFF
--- a/masking-json/pom.xml
+++ b/masking-json/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.visionarts</groupId>
     <artifactId>power-jambda-pom</artifactId>
-    <version>0.9.18-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>masking-json</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>com.visionarts</groupId>
   <artifactId>power-jambda-pom</artifactId>
-  <version>0.9.18-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Power Jambda :: Parent</name>
   <description>
@@ -73,6 +73,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
+    <jmockit.version>1.25</jmockit.version>
   </properties>
 
   <dependencyManagement>
@@ -105,7 +106,7 @@
       <dependency>
         <groupId>org.jmockit</groupId>
         <artifactId>jmockit</artifactId>
-        <version>1.25</version>
+        <version>${jmockit.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -175,6 +176,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.20</version>
+          <configuration>
+            <argLine>
+              -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+            </argLine>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/power-jambda-core/pom.xml
+++ b/power-jambda-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.visionarts</groupId>
     <artifactId>power-jambda-pom</artifactId>
-    <version>0.9.18-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>power-jambda-core</artifactId>

--- a/power-jambda-core/src/main/java/com/visionarts/powerjambda/LambdaApplication.java
+++ b/power-jambda-core/src/main/java/com/visionarts/powerjambda/LambdaApplication.java
@@ -134,7 +134,7 @@ public class LambdaApplication {
         application = null;
     }
 
-    protected void handle(InputStream input, OutputStream output, Context context) throws Exception {
+    public void handle(InputStream input, OutputStream output, Context context) throws Exception {
         LambdaLoggerHelper.putThreadContext(context);
         logger.debug("Starting request handler: requestId: {}", context.getAwsRequestId());
         try {

--- a/power-jambda-core/src/main/java/com/visionarts/powerjambda/LambdaApplication.java
+++ b/power-jambda-core/src/main/java/com/visionarts/powerjambda/LambdaApplication.java
@@ -54,19 +54,23 @@ import org.apache.logging.log4j.Logger;
  * }
  * </pre>
  */
-public final class LambdaApplication {
+public class LambdaApplication {
 
-    private static final Logger logger = LogManager.getLogger(LambdaApplication.class);
-    private static final String APPLICATION_NAME = LambdaApplication.class.getSimpleName();
+    protected static final Logger logger = LogManager.getLogger(LambdaApplication.class);
+    protected static final String APPLICATION_NAME = LambdaApplication.class.getSimpleName();
 
-    private static LambdaApplication application;
+    protected static LambdaApplication application;
 
-    private final ApplicationContext applicationContext;
-    private final ActionRouter router;
-    private final ObjectMapper om;
+    protected ApplicationContext applicationContext;
+    protected ActionRouter router;
+    protected ObjectMapper om;
 
     static {
         initialize();
+    }
+
+    protected LambdaApplication() {
+        this(LambdaApplication.class);
     }
 
     private LambdaApplication(Class<?> mainApplicationClazz) {
@@ -130,7 +134,7 @@ public final class LambdaApplication {
         application = null;
     }
 
-    private void handle(InputStream input, OutputStream output, Context context) throws Exception {
+    protected void handle(InputStream input, OutputStream output, Context context) throws Exception {
         LambdaLoggerHelper.putThreadContext(context);
         logger.debug("Starting request handler: requestId: {}", context.getAwsRequestId());
         try {
@@ -144,7 +148,7 @@ public final class LambdaApplication {
         }
     }
 
-    private AwsProxyRequest parseRequest(InputStream input)
+    protected AwsProxyRequest parseRequest(InputStream input)
             throws ClientErrorException, InternalErrorException {
         try {
             AwsProxyRequest request = om.readValue(input, AwsProxyRequest.class);
@@ -157,7 +161,7 @@ public final class LambdaApplication {
         }
     }
 
-    private void writeResponse(AwsProxyResponse response, OutputStream output) {
+    protected void writeResponse(AwsProxyResponse response, OutputStream output) {
         logger.debug("Writing response: {}", () -> Utils.writeValueAsString(response));
         try {
             om.writeValue(output, response);

--- a/power-jambda-core/src/main/java/com/visionarts/powerjambda/actions/AbstractLambdaAction.java
+++ b/power-jambda-core/src/main/java/com/visionarts/powerjambda/actions/AbstractLambdaAction.java
@@ -77,7 +77,7 @@ public abstract class AbstractLambdaAction<T, ActionResultT>
     }
 
     @Override
-    protected final void afterHandle(ActionRequest<T> actionRequest, Context context) throws Exception {
+    protected final void afterHandle(ActionRequest<T> actionRequest, Context context) {
         try {
             afterAction(actionRequest, context);
         } finally {
@@ -109,8 +109,9 @@ public abstract class AbstractLambdaAction<T, ActionResultT>
     @Override
     protected UnsafeBiConsumer<ActionRequest<T>, Context> loggerBeforeHandle() {
         return (r, c) ->
-                logger.info("Starting {} body: {} ({})",
-                    () -> this.getClass().getName(), () -> actionBodyType().getName(), () -> maskableJson(r.getBody()));
+            logger.info("Starting {} method: {} path: {} params: {} body: {} ({})",
+                () -> this.getClass().getName(), r::getMethod, r::getPath, r::getPathParameters,
+                () -> actionBodyType().getName(), () -> maskableJson(r.getBody()));
     }
 
     @Override

--- a/power-jambda-core/src/test/java/com/visionarts/powerjambda/AuditLoggingTest.java
+++ b/power-jambda-core/src/test/java/com/visionarts/powerjambda/AuditLoggingTest.java
@@ -1,0 +1,94 @@
+package com.visionarts.powerjambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.visionarts.powerjambda.actions.models.ComplexData;
+import com.visionarts.powerjambda.actions.models.Person;
+import com.visionarts.powerjambda.testing.AwsProxyRequestBuilder;
+import com.visionarts.powerjambda.testing.MockLambdaContext;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.apache.logging.log4j.core.layout.JsonLayout;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+
+
+public class AuditLoggingTest {
+
+    private static final String REQUEST_JSON_TEMPLATE = "requests/awsproxyrequest_api-gateway.json";
+    private static final Context mockContext = new MockLambdaContext();
+    private static final String LOGGER_NAME = "audit-logger";
+
+    private ActionRouter router;
+    private InputStream requestJsonStream;
+    private StringWriter writer;
+
+    @Before
+    public void setUp() throws Exception {
+        router = new ActionRouter(new ApplicationContext(this.getClass()));
+        requestJsonStream = this.getClass().getClassLoader().getResourceAsStream(REQUEST_JSON_TEMPLATE);
+
+        writer = new StringWriter();
+        Appender appender = WriterAppender.createAppender(
+                JsonLayout.createDefaultLayout(), null, writer, LOGGER_NAME, false, true);
+        LoggerContext.getContext(false).getConfiguration()
+                .getRootLogger().addAppender(appender, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        LoggerContext.getContext(false).getConfiguration()
+                .getRootLogger().removeAppender(LOGGER_NAME);
+    }
+
+    @Test
+    public void testAuditLog() throws Exception {
+        //Given
+        ComplexData body = new ComplexData() {{
+            setPerson(new Person() {{
+                name = "bar";
+                age = 10;
+            }});
+        }};
+
+        //When
+        AwsProxyRequest req = new AwsProxyRequestBuilder(requestJsonStream)
+                .resourcePath("/test_action3")
+                .httpMethod("POST")
+                .body(body)
+                .build();
+
+        AwsProxyResponse res = router.apply(req, mockContext);
+
+        //Then
+        assertEquals(200, res.getStatusCode());
+
+        List<String> messages = Arrays.stream(writer.toString().split("\n"))
+                .filter(s -> s.contains("\"message\""))
+                .collect(Collectors.toList());
+
+        assertThat(messages.get(0), containsString(
+                "Starting com.visionarts.powerjambda.actions.TestAction3 " +
+                        "method: POST path: /path/to/resource params: {proxy=path/to/resource} " +
+                        "body: com.visionarts.powerjambda.actions.models.ComplexData " +
+                        "({\\\"count\\\":1,\\\"persons\\\":[{\\\"name\\\":\\\"bar\\\",\\\"age\\\":10}]})"));
+        assertThat(messages.get(1), containsString(
+                "Returned action result: " +
+                        "{\\\"persons\\\":[{\\\"name\\\":\\\"bar\\\",\\\"age\\\":10}," +
+                        "{\\\"name\\\":\\\"BAR\\\",\\\"age\\\":20}],\\\"count\\\":2}"));
+        assertThat(messages.get(2), containsString(
+                "End com.visionarts.powerjambda.actions.TestAction3"));
+        assertThat(messages.get(3), containsString("Response status code: 200"));
+    }
+}

--- a/power-jambda-core/src/test/java/com/visionarts/powerjambda/OverrideLambdaApplicationTest.java
+++ b/power-jambda-core/src/test/java/com/visionarts/powerjambda/OverrideLambdaApplicationTest.java
@@ -67,7 +67,7 @@ public class OverrideLambdaApplicationTest {
         }
 
         @Override
-        protected void handle(InputStream input, OutputStream output, Context context) throws Exception {
+        public void handle(InputStream input, OutputStream output, Context context) throws Exception {
 
             AwsProxyResponse response = new ActionRouter(this.applicationContext) {
                 @Override

--- a/power-jambda-core/src/test/java/com/visionarts/powerjambda/OverrideLambdaApplicationTest.java
+++ b/power-jambda-core/src/test/java/com/visionarts/powerjambda/OverrideLambdaApplicationTest.java
@@ -1,0 +1,82 @@
+package com.visionarts.powerjambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.visionarts.powerjambda.actions.TestAction3;
+import com.visionarts.powerjambda.actions.models.ComplexData;
+import com.visionarts.powerjambda.actions.models.Person;
+import com.visionarts.powerjambda.testing.AwsProxyRequestBuilder;
+import com.visionarts.powerjambda.testing.MockLambdaContext;
+import com.visionarts.powerjambda.testutils.JsonUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+
+public class OverrideLambdaApplicationTest {
+
+    private static final String REQUEST_JSON_TEMPLATE = "requests/awsproxyrequest_api-gateway.json";
+    private static final Context mockContext = new MockLambdaContext();
+
+    private InputStream requestJsonStream;
+    private OutputStream output;
+
+    @Before
+    public void setUp() throws Exception {
+        requestJsonStream = this.getClass().getClassLoader().getResourceAsStream(REQUEST_JSON_TEMPLATE);
+        output = new ByteArrayOutputStream();
+    }
+
+    @Test
+    public void requestTestAction2ButRouteToTestAction3() throws Exception {
+        //Given
+        ComplexData expect = new ComplexData();
+        Person person = new Person();
+        expect.setPerson(person);
+        person.name = "foo";
+        person.age = 10;
+
+        //When
+        InputStream input = new AwsProxyRequestBuilder(requestJsonStream)
+                .resourcePath("/test_action2")
+                .httpMethod("POST")
+                .body(expect)
+                .buildAsStream();
+
+        ExtendedLambdaApplication.run(input, output, mockContext);
+
+        //Then
+        AwsProxyResponse res = JsonUtils.parseAwsProxyResponse(output);
+        assertEquals(200, res.getStatusCode());
+
+        // Requested "/test_action2" but `findAction` in ExtendedLambdaApplication returns TestAction3.class.
+        assertThat(JsonUtils.readValue(res.getBody(), ComplexData.class), instanceOf(ComplexData.class));
+    }
+
+    private static class ExtendedLambdaApplication extends LambdaApplication {
+
+        public static void run(InputStream input, OutputStream output, Context context) throws Exception {
+            new ExtendedLambdaApplication().handle(input, output, context);
+        }
+
+        @Override
+        protected void handle(InputStream input, OutputStream output, Context context) throws Exception {
+
+            AwsProxyResponse response = new ActionRouter(this.applicationContext) {
+                @Override
+                protected Optional<Class<?>> findAction(String packagePath, AwsProxyRequest request) {
+                    return Optional.of(TestAction3.class);
+                }
+            }.apply(parseRequest(input), context);
+
+            writeResponse(response, output);
+        }
+    }
+}

--- a/power-jambda-events/pom.xml
+++ b/power-jambda-events/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.visionarts</groupId>
     <artifactId>power-jambda-pom</artifactId>
-    <version>0.9.18-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>power-jambda-events</artifactId>


### PR DESCRIPTION
This PR is to:

1. Enhance logging for audit requirements.
2. Change the access modifiers in LambdaApplication to make an option to override `findAction` due to the performance issue of reflection. 
3. Add the VM parameter `javaagent` in the configuration of maven-surefire-plugin for Java11.
https://stackoverflow.com/questions/56787777/virtualmachine-attachpid-fails-with-java-io-ioexception-can-not-attach-to-cur
